### PR TITLE
feat: Add Text to PDF Conversion Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,17 @@ The Node plugin serves as a foundational component of Eliza OS, bridging core No
 
 ## Features
 
-- **PDF Processing**: PDF text extraction and parsing
-
-// ... existing code ...
+-   **PDF Processing**: PDF text extraction and parsing
+-   **Text to PDF conversion** with flexible output options (save to disk or get as buffer)
 
 ## Services
 
 ### PdfService
 
-Extracts and processes text content from PDF files.
-
-// ... existing code ...
+-   Extracts and processes text content from PDF files
+-   Converts text content to PDF with configurable output options
+    -   Save directly to disk
+    -   Get as buffer for further processing
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "tsup.config.ts"
   ],
   "dependencies": {
+    "pdf-lib": "^1.17.1",
     "pdfjs-dist": "4.7.76"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      pdf-lib:
+        specifier: ^1.17.1
+        version: 1.17.1
       pdfjs-dist:
         specifier: 4.7.76
         version: 4.7.76
@@ -199,6 +202,12 @@ packages:
   '@mapbox/node-pre-gyp@1.0.11':
     resolution: {integrity: sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==}
     hasBin: true
+
+  '@pdf-lib/standard-fonts@1.0.0':
+    resolution: {integrity: sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==}
+
+  '@pdf-lib/upng@1.0.1':
+    resolution: {integrity: sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -593,6 +602,9 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
@@ -608,6 +620,9 @@ packages:
   path2d@0.2.2:
     resolution: {integrity: sha512-+vnG6S4dYcYxZd+CZxzXCNKdELYZSKfohrk98yajCo1PtRoDgCTrrwOvK1GT0UoAdVszagDVllQc0U1vaX4NUQ==}
     engines: {node: '>=6'}
+
+  pdf-lib@1.17.1:
+    resolution: {integrity: sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==}
 
   pdfjs-dist@4.7.76:
     resolution: {integrity: sha512-8y6wUgC/Em35IumlGjaJOCm3wV4aY/6sqnIT3fVW/67mXsOZ9HWBn8GDKmJUK0GSzpbmX3gQqwfoFayp78Mtqw==}
@@ -770,6 +785,9 @@ packages:
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
   tsup@8.3.5:
     resolution: {integrity: sha512-Tunf6r6m6tnZsG9GYWndg0z8dEV7fD733VBFzFJ5Vcm1FtlXB8xBD/rtrBi2a3YKEV7hHtxiZtW5EAVADoe1pA==}
@@ -958,6 +976,14 @@ snapshots:
       - encoding
       - supports-color
     optional: true
+
+  '@pdf-lib/standard-fonts@1.0.0':
+    dependencies:
+      pako: 1.0.11
+
+  '@pdf-lib/upng@1.0.1':
+    dependencies:
+      pako: 1.0.11
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -1337,6 +1363,8 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  pako@1.0.11: {}
+
   path-is-absolute@1.0.1:
     optional: true
 
@@ -1349,6 +1377,13 @@ snapshots:
 
   path2d@0.2.2:
     optional: true
+
+  pdf-lib@1.17.1:
+    dependencies:
+      '@pdf-lib/standard-fonts': 1.0.0
+      '@pdf-lib/upng': 1.0.1
+      pako: 1.0.11
+      tslib: 1.14.1
 
   pdfjs-dist@4.7.76:
     optionalDependencies:
@@ -1531,6 +1566,8 @@ snapshots:
   tree-kill@1.2.2: {}
 
   ts-interface-checker@0.1.13: {}
+
+  tslib@1.14.1: {}
 
   tsup@8.3.5(postcss@8.5.1)(typescript@5.7.3)(yaml@2.7.0):
     dependencies:

--- a/src/services/pdf.ts
+++ b/src/services/pdf.ts
@@ -1,49 +1,115 @@
-import {
-    type IAgentRuntime,
-    type IPdfService,
-    Service,
-    ServiceType,
-} from "@elizaos/core";
-import { getDocument, type PDFDocumentProxy } from "pdfjs-dist";
-import type { TextItem, TextMarkedContent } from "pdfjs-dist/types/src/display/api";
+import { type IAgentRuntime, type IPdfService, Service, ServiceType } from "@elizaos/core"
+import { getDocument, type PDFDocumentProxy } from "pdfjs-dist"
+import type { TextItem, TextMarkedContent } from "pdfjs-dist/types/src/display/api"
+import { PDFDocument, StandardFonts, rgb } from "pdf-lib"
+import { writeFile } from "fs/promises"
+
+export enum PdfOutputType {
+	SAVE_TO_DISK = "save_to_disk",
+	BUFFER = "buffer",
+}
+
+interface PdfOutputOptions {
+	type: PdfOutputType
+	filename?: string // Required for SAVE_TO_DISK type
+}
 
 export class PdfService extends Service implements IPdfService {
-    static serviceType: ServiceType = ServiceType.PDF;
+	static serviceType: ServiceType = ServiceType.PDF
 
-    constructor() {
-        super();
-    }
+	constructor() {
+		super()
+	}
 
-    getInstance(): IPdfService {
-        return PdfService.getInstance();
-    }
+	getInstance(): IPdfService {
+		return PdfService.getInstance()
+	}
 
-    async initialize(_runtime: IAgentRuntime): Promise<void> {}
+	async initialize(_runtime: IAgentRuntime): Promise<void> {}
 
-    async convertPdfToText(pdfBuffer: Buffer): Promise<string> {
-        // Convert Buffer to Uint8Array
-        const uint8Array = new Uint8Array(pdfBuffer);
+	async convertPdfToText(pdfBuffer: Buffer): Promise<string> {
+		// Convert Buffer to Uint8Array
+		const uint8Array = new Uint8Array(pdfBuffer)
 
-        const pdf: PDFDocumentProxy = await getDocument({ data: uint8Array })
-            .promise;
-        const numPages = pdf.numPages;
-        const textPages: string[] = [];
+		const pdf: PDFDocumentProxy = await getDocument({ data: uint8Array }).promise
+		const numPages = pdf.numPages
+		const textPages: string[] = []
 
-        for (let pageNum = 1; pageNum <= numPages; pageNum++) {
-            const page = await pdf.getPage(pageNum);
-            const textContent = await page.getTextContent();
-            const pageText = textContent.items
-                .filter(isTextItem)
-                .map((item) => item.str)
-                .join(" ");
-            textPages.push(pageText);
-        }
+		for (let pageNum = 1; pageNum <= numPages; pageNum++) {
+			const page = await pdf.getPage(pageNum)
+			const textContent = await page.getTextContent()
+			const pageText = textContent.items
+				.filter(isTextItem)
+				.map((item) => item.str)
+				.join(" ")
+			textPages.push(pageText)
+		}
 
-        return textPages.join("\n");
-    }
+		return textPages.join("\n")
+	}
+
+	async convertTextToPdf(text: string, options: PdfOutputOptions = { type: PdfOutputType.BUFFER }): Promise<Buffer | void> {
+		try {
+			// Create a new PDF document
+			const pdfDoc = await PDFDocument.create()
+			let currentPage = pdfDoc.addPage()
+			const font = await pdfDoc.embedFont(StandardFonts.Helvetica)
+			const fontSize = 12
+			const lineHeight = fontSize * 1.2
+			const margin = 50
+
+			// Get page dimensions
+			const { width, height } = currentPage.getSize()
+			const maxWidth = width - 2 * margin
+
+			const lines = text.split("\n")
+			let y = height - margin
+
+			for (const line of lines) {
+				// Check if we need a new page
+				if (y < margin) {
+					currentPage = pdfDoc.addPage()
+					y = height - margin
+				}
+
+				// Draw the text line
+				currentPage.drawText(line, {
+					x: margin,
+					y: y,
+					size: fontSize,
+					font: font,
+					color: rgb(0, 0, 0),
+					maxWidth: maxWidth,
+				})
+
+				// Move to next line position
+				y -= lineHeight
+			}
+
+			// Save the PDF
+			const pdfBytes = await pdfDoc.save()
+			const pdfBuffer = Buffer.from(pdfBytes)
+
+			// Handle different output types
+			switch (options.type) {
+				case PdfOutputType.SAVE_TO_DISK:
+					if (!options.filename) {
+						throw new Error("Filename is required when output type is SAVE_TO_DISK")
+					}
+					await writeFile(options.filename, pdfBuffer)
+					return
+
+				case PdfOutputType.BUFFER:
+				default:
+					return pdfBuffer
+			}
+		} catch (error) {
+			throw new Error(`Failed to convert text to PDF: ${error instanceof Error ? error.message : "Unknown error"}`)
+		}
+	}
 }
 
 // Type guard function
 function isTextItem(item: TextItem | TextMarkedContent): item is TextItem {
-    return "str" in item;
+	return "str" in item
 }


### PR DESCRIPTION
## Description
This PR adds a new `convertTextToPdf` function to the `PdfService` class, enabling text-to-PDF conversion with flexible output options. The feature complements the existing PDF text extraction functionality.

## Changes
- Added new `convertTextToPdf` method to `PdfService`
- Implemented two output options:
  - Save directly to disk
  - Get as buffer for further processing
- Added proper error handling and type safety
- Updated documentation to reflect new functionality

## Usage Examples

### Save to Disk
```typescript
await pdfService.convertTextToPdf(text, { 
    type: PdfOutputType.SAVE_TO_DISK,
    filename: 'path/to/save/document.pdf'
});
```

### Get as Buffer
```typescript
const pdfBuffer = await pdfService.convertTextToPdf(text);
// or explicitly
const pdfBuffer = await pdfService.convertTextToPdf(text, { 
    type: PdfOutputType.BUFFER 
});
```